### PR TITLE
Fix a bug where local repo's hook don't run

### DIFF
--- a/.base-hook
+++ b/.base-hook
@@ -2,8 +2,9 @@
 
 set -eu
 
-if [ -f ".git/hooks/${0}" ]; then
-  ".git/hooks/${0}" $@
+script_name=$(basename $0)
+if [ -f ".git/hooks/${script_name}" ]; then
+  ".git/hooks/${script_name}" $@
 fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"


### PR DESCRIPTION
It looks like `$0' is the full path of the script and not the basename. This is
causing the test for file existence to fail which in turn causes the local
hooks to be skipped