### PR TITLE
Update the base hook to detect the proper git dir

### DIFF
--- a/.base-hook
+++ b/.base-hook
@@ -2,9 +2,10 @@
 
 set -eu
 
+git_dir=$( git rev-parse --git-dir )
 script_name=$(basename $0)
-if [ -f ".git/hooks/${script_name}" ]; then
-  ".git/hooks/${script_name}" $@
+if [ -f "${git_dir}/hooks/${script_name}" ]; then
+  "${git_dir}/hooks/${script_name}" $@
 fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"


### PR DESCRIPTION
The hook env values don't always include GIT_DIR and the working directory
isn't always the checkout root. A few hooks execute inside the git dir and
bare repositories execute all hooks in the git dir. This change simply uses
the rev-parse command to detect the correct git dir relative to the current
working directory