### PR TITLE
Make post-merge commit hooks submodule-aware

### DIFF
--- a/post-merge.d/scan-merged-commits-for-credentials
+++ b/post-merge.d/scan-merged-commits-for-credentials
@@ -4,7 +4,21 @@ if ! command -v "cred-alert-cli" >/dev/null 2>&1; then
   exit
 fi
 
-output=$( git diff $( cat .git/ORIG_HEAD )..HEAD | cred-alert-cli scan --diff --show-suspected-credentials)
+if [ -e .git/ORIG_HEAD ] ; then
+  ORIG_HEAD=.git/ORIG_HEAD
+elif [ -f .git ] ; then
+  # In a submodule
+  ORIG_HEAD=$(sed 's/^gitdir: *//' .git)/ORIG_HEAD
+  if [ ! -e "${ORIG_HEAD}" ] ; then
+      echo "$PWD/.git ==> $(cat .git) doesn't point to an ORIG_HEAD file"
+      exit 0
+  fi
+else
+  echo "$PWD/.git/ORIG_HEAD not found, can't check for possible credentials in the merge"
+  exit 0
+fi
+
+output=$( git diff $( cat "${ORIG_HEAD}" )..HEAD | cred-alert-cli scan --diff --show-suspected-credentials)
 status="$?"
 if [ "${status}" -eq 3 ]; then
   printf "\n"


### PR DESCRIPTION
On the capi team we've been getting ".git/ORIG_HEAD: Not a directory" error messages after merging in the cloud_controller_ng directory, as it's a submodule off cf-release. This commit looks to fix it.