### PR TITLE
Request to show err msg when cred-alert-cli fails

### DIFF
--- a/commit-msg.d/scan-commit-msg-for-credentials
+++ b/commit-msg.d/scan-commit-msg-for-credentials
@@ -18,5 +18,10 @@ if [ "$status" -eq 3 ]; then
   printf "=====================================================================\n"
   awk '/# ------------------------ >8 ------------------------/ {exit} {print}' "${1}" | grep -v '^#'
   printf "=====================================================================\n"
+elif [ "${status}" -ne 0 ]; then
+  printf "\n"
+  printf "(git-hooks-core): cred-alert exited with status: %d" "${status}"
+  printf "%s" "$output"
+  printf "\n"
 fi
 exit "$status"

--- a/post-merge.d/scan-merged-commits-for-credentials
+++ b/post-merge.d/scan-merged-commits-for-credentials
@@ -23,5 +23,10 @@ if [ "${status}" -eq 3 ]; then
   printf "\n"
   printf "%s" "$output"
   printf "\n"
+elif [ "${status}" -ne 0 ]; then
+  printf "\n"
+  printf "(git-hooks-core): cred-alert exited with status: %d" "${status}"
+  printf "%s" "$output"
+  printf "\n"
 fi
 exit "${status}"

--- a/pre-commit.d/scan-diff-for-credentials
+++ b/pre-commit.d/scan-diff-for-credentials
@@ -41,5 +41,10 @@ if [ "${status}" -eq 3 ]; then
   printf "\n"
   printf "%s" "$output"
   printf "\n"
+elif [ "${status}" -ne 0 ]; then
+  printf "\n"
+  printf "(git-hooks-core): cred-alert exited with status: %d" "${status}"
+  printf "%s" "$output"
+  printf "\n"
 fi
 exit "${status}"


### PR DESCRIPTION
This PR expands upon the following PR that's been open since 2018.  Whenever cred-alert-cli fails (such as when scanning large files), git-hooks-core doesn't print anything and causes git commit to appear to no-op.  These changes pass the error message along to the user so they actually know what failed.

Original PR: https://github.com/pivotal-cf/git-hooks-core/pull/11